### PR TITLE
Add HR info to sleep entries

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: bin/oura-to-runalyze -y
+worker: bin/oura-to-runalyze -yesterday

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bin/oura-to-runalyze -y

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![Tests Status Badge](https://github.com/lildude/oura-to-runalyze/workflows/Tests/badge.svg)
 
 Sync health data from Oura to Runalyze.
+Currently only sleep data and resting heart rate as this normally lowest during sleep.
+The Runalyze Sleep Quality metric is calculated by taking the Oura Sleep Score, dividing by 10 and rounding down.
 
 ## Installation
 
@@ -56,3 +58,7 @@ $ oura-to-runalyze -start 2020-01-01 -end 2020-03-31
 Successfully sync'd to Runalyze
 $
 ```
+
+## Releasing
+
+This project uses [GoReleaser](https://goreleaser.com) via GitHub Actions to make the releases quick and easy. When I'm ready for a new release, I push a new tag and the workflow takes care of things.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// +heroku goVersion go1.15
 module github.com/lildude/oura-to-runalyze
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/joho/godotenv v1.3.0
 	github.com/lildude/oura v0.2.0
-	github.com/lildude/runalyze v0.2.0
+	github.com/lildude/runalyze v0.2.1
 	golang.org/x/net v0.0.0-20201216054612-986b41b23924 // indirect
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/lildude/runalyze v0.1.0 h1:voeK42Jy+8mQRRnPU8YKFXwmMkULeacq2gZTMiTZ9B
 github.com/lildude/runalyze v0.1.0/go.mod h1:Ws3UWALwblcIzgeb+unbUIrxTQ/8BkE6s94K4VoYT4A=
 github.com/lildude/runalyze v0.2.0 h1:OoLflq+7F6i5OSYOXGwL1W01kfAG0SoeZ0huS8QkpM4=
 github.com/lildude/runalyze v0.2.0/go.mod h1:Ws3UWALwblcIzgeb+unbUIrxTQ/8BkE6s94K4VoYT4A=
+github.com/lildude/runalyze v0.2.1 h1:a5KYofmb9mc6RPUe0LELGFatxXRrbdIyvLJi1ka78GA=
+github.com/lildude/runalyze v0.2.1/go.mod h1:Ws3UWALwblcIzgeb+unbUIrxTQ/8BkE6s94K4VoYT4A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ func createMetrics(sleeps []oura.Sleep) runalyze.Metrics {
 			LightSleepDuration: secToMin(s.Light),
 			DeepSleepDuration:  secToMin(s.Deep),
 			AwakeDuration:      secToMin(s.Awake),
+			HrAverage:          int(s.HrAverage),
+			HrLowest:           int(s.HrLowest),
 			Quality:            int(s.Score / 10),
 		})
 

--- a/main_test.go
+++ b/main_test.go
@@ -128,6 +128,7 @@ func Test_createMetrics(t *testing.T) {
 			Deep:         2910,
 			Awake:        1230,
 			Score:        85,
+			HrAverage:    60,
 			HrLowest:     49,
 		},
 	}
@@ -140,6 +141,8 @@ func Test_createMetrics(t *testing.T) {
 				LightSleepDuration: 171,
 				DeepSleepDuration:  49,
 				AwakeDuration:      21,
+				HrAverage:          60,
+				HrLowest:           49,
 				Quality:            8,
 			},
 		},


### PR DESCRIPTION
The Runalyze Sleep API has been extended to accept HR information so this PR adds it to the payload of each sync'd entry.